### PR TITLE
chore: bump version to 3.0.1

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+dde-manual-content (3.0.1) unstable; urgency=medium
+
+  * chore: remove unnecessary spaces
+
+ -- zhangkun <zhangkun2@uniontech.com>  Tue, 24 Jun 2025 17:48:04 +0800
+
 dde-manual-content (3.0.0) unstable; urgency=medium
 
   * chore: update manual for DDE 7


### PR DESCRIPTION
update changelog to 3.0.1

## Summary by Sourcery

Chores:
- Update debian/changelog to version 3.0.1