### PR TITLE
chore: bump version to 3.0.2

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+dde-manual-content (3.0.2) unstable; urgency=medium
+
+  * chore: update dde content
+
+ -- zhangkun <zhangkun2@uniontech.com>  Fri, 18 Jul 2025 14:48:04 +0800
+
 dde-manual-content (3.0.1) unstable; urgency=medium
 
   * chore: remove unnecessary spaces


### PR DESCRIPTION
release 3.0.2

Log: as title

## Summary by Sourcery

Chores:
- Update Debian changelog entry to reflect version 3.0.2