### PR TITLE
chore: update changelog to 3.0.8

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+dde-manual-content (3.0.8) unstable; urgency=medium
+
+  * chore: update content
+
+ -- zhangkun <zhangkun2@uniontech.com>  Fri, 13 Mar 2026 11:11:09 +0800
+
 dde-manual-content (3.0.7) unstable; urgency=medium
 
   * docs: fix image paths and formatting in Chinese documentation


### PR DESCRIPTION
## 更新说明

自动更新 changelog 到版本 3.0.8

### 变更内容
- 更新 debian/changelog

### 版本信息
- 新版本: 3.0.8
- 目标分支: master

## Summary by Sourcery

Chores:
- Refresh Debian changelog metadata to reflect version 3.0.8 targeting the master branch.