### PR TITLE
chore: update changelog to 3.0.11

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+dde-manual-content (3.0.11) unstable; urgency=medium
+
+  * docs(dde): add concat screen docs and update developer mode
+
+ -- zhangkun <zhangkun2@uniontech.com>  Thu, 04 Jun 2026 19:33:01 +0800
+
 dde-manual-content (3.0.10) unstable; urgency=medium
 
   * docs: update documentation formatting and content


### PR DESCRIPTION
## 更新说明

自动更新 changelog 到版本 3.0.11

### 变更内容
- 更新 debian/changelog

### 版本信息
- 新版本: 3.0.11
- 目标分支: master

## Summary by Sourcery

Chores:
- Bump Debian changelog entry to version 3.0.11 targeting master.